### PR TITLE
Create nano-project.yaml

### DIFF
--- a/chap4/nano-project.yaml
+++ b/chap4/nano-project.yaml
@@ -1,0 +1,87 @@
+# worker-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+      - name: worker
+        image: schoolofdevops/worker:latest
+---
+# db-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - name: db
+        image: postgres:9.4
+        ports:
+        - containerPort: 5432
+---
+# db-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: db
+---
+# result-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: result
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: result
+  template:
+    metadata:
+      labels:
+        app: result
+    spec:
+      containers:
+      - name: result
+        image: schoolofdevops/vote-result
+        ports:
+        - containerPort: 80
+---
+# result-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: result
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30400
+  selector:
+    app: result


### PR DESCRIPTION
| Service Name | Image                        | Service Type       | Service Port | Node Port |
| :----------- | :--------------------------- | :----------------- | :----------- | :-------- |
| worker       | schoolofdevops/worker:latest | No Service Needed  | N/A          | N/A       |
| db           | postgres:9.4                | ClusterIP          | 5432         | N/A       |
| result       | schoolofdevops/vote-result  | NodePort           | 80           | 30400     |

This cmd is also required after
`kubectl set env deployment db POSTGRES_HOST_AUTH_METHOD=trust`